### PR TITLE
WIP on issue #1524

### DIFF
--- a/mchf-eclipse/drivers/audio/tx_processor.c
+++ b/mchf-eclipse/drivers/audio/tx_processor.c
@@ -22,6 +22,7 @@
 #include "freedv_uhsdr.h"
 #include "freq_shift.h"
 #include "cw_gen.h"
+#include "cw_decoder.h"
 
 #include "usbd_audio_if.h"
 
@@ -881,6 +882,12 @@ static bool TxProcessor_CW(audio_block_t a_block, iq_buffer_t* iq_buf_p, uint16_
     else
     {
         memset ( a_block, 0, sizeof( a_block[0]) * blockSize );
+    }
+
+    if (ts.cw_keyer_mode == CW_KEYER_MODE_STRAIGHT)
+    {
+        // Send the sidetone through the RX decoder to interpret the keyed code
+        CwDecode_RxProcessor(a_block, blockSize);
     }
 
     return signal_active;


### PR DESCRIPTION
Experimenting with sending the sidetone audio through the CW RX decoder to interpret operator input in straight key mode.

To make this usable you currently need to turn the CW TX->RX delay up. Otherwise the decoder only receives the TX audio whle the key is down.

To make this work properly, we probably need to maintain two copies of the CW decoder state - one for TX and one for RX.